### PR TITLE
Added support for guzzlehttp/psr7 ^2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": ">=7.4",
     "guzzlehttp/guzzle": "^7.0",
-    "guzzlehttp/psr7": "^1.9"
+    "guzzlehttp/psr7": "^2.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
guzzlehttp/psr7 1.9.1 was conflicting with many packages including spatie/laravel-sitemap.